### PR TITLE
fix monopoly_realistischTest.py to support if __name__ == __main__

### DIFF
--- a/tests/monopoly/monopoly_realistischTest.py
+++ b/tests/monopoly/monopoly_realistischTest.py
@@ -107,7 +107,10 @@ def correctAverageDiv2(test):
 					return line
 			return ""
 
-		line = findline(lib.outputOf(_originalFileName))
+		line = findline(lib.outputOf(
+			_originalFileName,
+			overwriteAttributes=[("__name__", "__main__")])
+		)
 
 		info = ""
 		if assertlib.numberOnLine(75, line):


### PR DESCRIPTION
Deze opdracht wordt nu gebruikt bij pyprog en daar is `if __name__ == "__main__"` de norm. Vandaar deze fix :)